### PR TITLE
Feature: disable countries for shipping

### DIFF
--- a/bp_admin/templates/admin/countries.html
+++ b/bp_admin/templates/admin/countries.html
@@ -30,9 +30,9 @@
                         <tr>
                             <th>Name</th>
                             <th>Code</th>
-                            <th>State required</th>
-                            <th>VAT required</th>
-                            <th>Active</th>
+                            <th>Billing state required</th>
+                            <th>Billing VAT required</th>
+                            <th>Shipping allowed</th>
                             <th class="text-end">Actions</th>
                         </tr>
                     </thead>

--- a/bp_admin/templates/admin/countries.html
+++ b/bp_admin/templates/admin/countries.html
@@ -6,9 +6,9 @@
             event.preventDefault();
             updateButton(`update-country-${countryId}`, 1);
             await patchCountriesId(countryId, {
-                is_active: document.getElementById(`country-is-active-${countryId}`).checked,
-                state_required: document.getElementById(`country-state-required-${countryId}`).checked,
-                vat_required: document.getElementById(`country-vat-required-${countryId}`).checked,
+                allows_shipping: document.getElementById(`country-allows-shipping-${countryId}`).checked,
+                requires_billing_state: document.getElementById(`country-requires-billing-state-${countryId}`).checked,
+                requires_billing_vat: document.getElementById(`country-requires-billing-vat-${countryId}`).checked,
             });
             await patchSettings({
                 cached_at: null
@@ -42,20 +42,20 @@
                                 <td>{{ x.name }}</td>
                                 <td>{{ x.code }}</td>
                                 <td>
-                                    <input {{ 'checked' if x.state_required }}
-                                           id="country-state-required-{{ x.id }}"
+                                    <input {{ 'checked' if x.requires_billing_state }}
+                                           id="country-requires-billing-state-{{ x.id }}"
                                            class="form-check-input"
                                            type="checkbox">
                                 </td>
                                 <td>
-                                    <input {{ 'checked' if x.vat_required }}
-                                           id="country-vat-required-{{ x.id }}"
+                                    <input {{ 'checked' if x.requires_billing_vat }}
+                                           id="country-requires-billing-vat-{{ x.id }}"
                                            class="form-check-input"
                                            type="checkbox">
                                 </td>
                                 <td>
-                                    <input {{ 'checked' if x.is_active }}
-                                           id="country-is-active-{{ x.id }}"
+                                    <input {{ 'checked' if x.allows_shipping }}
+                                           id="country-allows-shipping-{{ x.id }}"
                                            class="form-check-input"
                                            type="checkbox">
                                 </td>

--- a/bp_admin/templates/admin/countries.html
+++ b/bp_admin/templates/admin/countries.html
@@ -6,6 +6,7 @@
             event.preventDefault();
             updateButton(`update-country-${countryId}`, 1);
             await patchCountriesId(countryId, {
+                is_active: document.getElementById(`country-is-active-${countryId}`).checked,
                 state_required: document.getElementById(`country-state-required-${countryId}`).checked,
                 vat_required: document.getElementById(`country-vat-required-${countryId}`).checked,
             });
@@ -31,6 +32,7 @@
                             <th>Code</th>
                             <th>State required</th>
                             <th>VAT required</th>
+                            <th>Active</th>
                             <th class="text-end">Actions</th>
                         </tr>
                     </thead>
@@ -48,6 +50,12 @@
                                 <td>
                                     <input {{ 'checked' if x.vat_required }}
                                            id="country-vat-required-{{ x.id }}"
+                                           class="form-check-input"
+                                           type="checkbox">
+                                </td>
+                                <td>
+                                    <input {{ 'checked' if x.is_active }}
+                                           id="country-is-active-{{ x.id }}"
                                            class="form-check-input"
                                            type="checkbox">
                                 </td>

--- a/bp_admin/templates/admin/orders_add.html
+++ b/bp_admin/templates/admin/orders_add.html
@@ -296,7 +296,7 @@
             if (shipmentMethodId !== null) {
                 const shipmentMethod = (await getShipmentMethodsId(shipmentMethodId)).data;
                 const shippingPhoneEl = document.getElementById("shipping-phone");
-                shippingPhoneEl.required = shipmentMethod.phone_required;
+                shippingPhoneEl.required = shipmentMethod.requires_billing_phone;
             }
         }
 

--- a/bp_admin/templates/admin/shipment_methods.html
+++ b/bp_admin/templates/admin/shipment_methods.html
@@ -52,7 +52,7 @@
                             <th>Unit price</th>
                             <th>Class</th>
                             <th>Zone</th>
-                            <th>Phone required</th>
+                            <th>Billing phone required</th>
                             <th class="text-end">Actions</th>
                         </tr>
                     </thead>

--- a/bp_admin/templates/admin/shipment_methods.html
+++ b/bp_admin/templates/admin/shipment_methods.html
@@ -18,7 +18,7 @@
             updateButton(`update-shipment-method-${methodId}`, 1);
             await patchShipmentMethodsId(methodId, {
                 unit_price: parseFloat(document.getElementById(`shipment-method-unit-price-${methodId}`).value),
-                phone_required: document.getElementById(`shipment-method-phone-required-${methodId}`).checked,
+                requires_billing_phone: document.getElementById(`shipment-method-requires-billing-phone-${methodId}`).checked,
             });
             window.location.reload();
         }
@@ -73,8 +73,8 @@
                                     {{ method.zone.region.name if method.zone.region }}
                                 </td>
                                 <td>
-                                    <input {{ 'checked' if method.phone_required }}
-                                           id="shipment-method-phone-required-{{ method.id }}"
+                                    <input {{ 'checked' if method.requires_billing_phone }}
+                                           id="shipment-method-requires-billing-phone-{{ method.id }}"
                                            class="form-check-input"
                                            type="checkbox">
                                 </td>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/esherpaio/web-framework.git
+git+https://github.com/esherpaio/web-framework.git@inactive_countries


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added “Shipping allowed” column and controls on Countries admin page.
* Improvements
  * Updated country settings labels to “Billing state required” and “Billing VAT required” for clarity.
  * Shipment Methods page now uses “Billing phone required” wording and consistent checkbox behavior.
  * Order creation form aligns phone requirement with shipment method settings.
* Chores
  * Pinned web framework dependency to a specific revision for stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->